### PR TITLE
Add a sneak/Shift key indicator to KeystrokeHud

### DIFF
--- a/src/main/java/io/github/darkkronicle/kronhud/gui/hud/KeystrokeHud.java
+++ b/src/main/java/io/github/darkkronicle/kronhud/gui/hud/KeystrokeHud.java
@@ -62,7 +62,7 @@ public class KeystrokeHud extends AbstractHudEntry {
         keystrokes.add(createFromKey(new Rectangle(36, 18, 17, 17), pos, client.options.rightKey));
 
         // Space
-        keystrokes.add(new Keystroke(new Rectangle(0, 54, 53, 7), pos, client.options.jumpKey, (stroke, matrices) -> {
+        keystrokes.add(new Keystroke(new Rectangle(18, 54, 35, 7), pos, client.options.jumpKey, (stroke, matrices) -> {
             Rectangle bounds = stroke.bounds;
             Rectangle spaceBounds = new Rectangle(bounds.x() + stroke.offset.x() + 4,
                     bounds.y() + stroke.offset.y() + 2,
@@ -73,6 +73,26 @@ public class KeystrokeHud extends AbstractHudEntry {
                         new Color((stroke.getFGColor().color() & 16579836) >> 2 | stroke.getFGColor().color() & -16777216));
             }
         }));
+        
+        // Shift
+        keystrokes.add(new Keystroke(new Rectangle(0, 54, 17, 7), pos, client.options.sneakKey, (stroke, matrices) -> {
+            Rectangle bounds = stroke.bounds;
+            Rectangle arrowHeadBounds = new Rectangle(bounds.x() + stroke.offset.x() + 1,
+                    bounds.y() + stroke.offset.y() + 2,
+                    3, 1);
+			Rectangle arrowBodyBounds = new Rectangle(bounds.x() + stroke.offset.x() + 2,
+                    bounds.y() + stroke.offset.y() + 1,
+                    1, 4);
+            if (shadow.getBooleanValue()) {
+                fillRect(matrices, arrowHeadBounds.offset(1, 1),
+                        new Color((stroke.getFGColor().color() & 16579836) >> 2 | stroke.getFGColor().color() & -16777216));
+				fillRect(matrices, arrowBodyBounds.offset(1, 1),
+                        new Color((stroke.getFGColor().color() & 16579836) >> 2 | stroke.getFGColor().color() & -16777216));
+            }
+            fillRect(matrices, arrowHeadBounds, stroke.getFGColor());
+            fillRect(matrices, arrowBodyBounds, stroke.getFGColor());
+        }));
+        
         KeyBinding.unpressAll();
         KeyBinding.updatePressedStates();
     }


### PR DESCRIPTION
Shift/sneak key is an important movement control that is currently missing. Its display is useful for demonstrating various tricks where sneaking is impossible or hard to infer from camera movement.
![image](https://user-images.githubusercontent.com/9787438/179508091-fab7a313-88e4-4ed5-bb79-c2e21b7bbd4a.png)
