### PR TITLE
Fix reach indicators

### DIFF
--- a/src/main/java/io/github/darkkronicle/kronhud/gui/hud/simple/ReachHud.java
+++ b/src/main/java/io/github/darkkronicle/kronhud/gui/hud/simple/ReachHud.java
@@ -5,6 +5,7 @@ import io.github.darkkronicle.kronhud.KronHUD;
 import io.github.darkkronicle.kronhud.config.KronConfig;
 import io.github.darkkronicle.kronhud.config.KronInteger;
 import io.github.darkkronicle.kronhud.gui.entry.SimpleTextHudEntry;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.projectile.ProjectileUtil;
 import net.minecraft.util.Identifier;
@@ -45,57 +46,11 @@ public class ReachHud extends SimpleTextHudEntry {
 
     @Override
     public String getPlaceholder() {
-        return "3.45 blocks";
+        return "2.97 blocks";
     }
 
-    private static Vec3d compareTo(Vec3d compare, Vec3d test, AtomicDouble max) {
-        double dist = compare.distanceTo(test);
-        if (dist > max.get()) {
-            max.set(dist);
-            return test;
-        }
-        return compare;
-    }
-
-    public static double getAttackDistance(Entity attacking, Entity receiving) {
-        Vec3d camera = attacking.getCameraPosVec(1);
-        Vec3d rotation = attacking.getRotationVec(1);
-
-        Vec3d maxPos = receiving.getPos();
-        AtomicDouble max = new AtomicDouble(0);
-
-        maxPos = compareTo(camera, maxPos.add(0, 0, receiving.getBoundingBox().maxZ), max);
-        maxPos = compareTo(camera, maxPos.add(0, 0, receiving.getBoundingBox().minZ), max);
-        maxPos = compareTo(camera, maxPos.add(0, receiving.getBoundingBox().maxY, 0), max);
-        maxPos = compareTo(camera, maxPos.add(0, receiving.getBoundingBox().minY, 0), max);
-        maxPos = compareTo(camera, maxPos.add(receiving.getBoundingBox().maxX, 0, 0), max);
-        maxPos = compareTo(camera, maxPos.add(receiving.getBoundingBox().minX, 0, 0), max);
-
-        // Max reach distance that want to account for
-        double d = max.get() + .5;
-        Vec3d possibleHits = camera.add(rotation.x * d, rotation.y * d, rotation.z * d);
-        Box box = attacking.getBoundingBox().stretch(rotation.multiply(d)).expand(1.0, 1.0, 1.0);
-
-
-        EntityHitResult result = ProjectileUtil.raycast(attacking, camera, possibleHits, box, entity -> entity.getId() == receiving.getId(), d);
-        if (result == null || result.getEntity() == null) {
-            // This should not happen...
-            return -1;
-        }
-        return camera.distanceTo(result.getPos());
-    }
-
-    public void updateDistance(Entity attacking, Entity receiving) {
-        double distance;
-        try {
-            distance = getAttackDistance(attacking, receiving);
-        } catch (Exception e) {
-            KronHUD.LOGGER.warn("Couldn't compute attack distance: ", e);
-            return;
-        }
+    public void updateDistance(double distance) {
         if (distance < 0) {
-            // This should not happen...
-            currentDist = "NaN";
             return;
         }
 

--- a/src/main/java/io/github/darkkronicle/kronhud/mixins/MixinPlayerEntity.java
+++ b/src/main/java/io/github/darkkronicle/kronhud/mixins/MixinPlayerEntity.java
@@ -25,9 +25,15 @@ public abstract class MixinPlayerEntity extends Entity {
     @Inject(method = "attack", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;getAttributeValue(Lnet/minecraft/entity/attribute/EntityAttribute;)D"))
     private void getReach(Entity entity, CallbackInfo ci){
         // This is only ever called when the client attacks. Without more work not possible to get when someone else attacks.
-        if (getId() == MinecraftClient.getInstance().player.getId() && entity != null){
-            ReachHud reachDisplayHud = (ReachHud) HudManager.getInstance().get(ReachHud.ID);
-            reachDisplayHud.updateDistance(this, entity);
+        MinecraftClient mc = MinecraftClient.getInstance();
+        assert mc != null;
+        assert mc.player != null;
+
+        if (getId() == mc.player.getId() && entity != null){
+            if (mc.crosshairTarget != null) {
+                ReachHud reachDisplayHud = (ReachHud) HudManager.getInstance().get(ReachHud.ID);
+                reachDisplayHud.updateDistance(this.getCameraPosVec(1).distanceTo(mc.crosshairTarget.getPos()));
+            }
             ComboHud comboHud = (ComboHud) HudManager.getInstance().get(ComboHud.ID);
             comboHud.onEntityAttack(entity);
         }


### PR DESCRIPTION
The previous reach indicators were inaccurate and occasionally presented values above the possible reach due to these inaccuracies. I have corrected this in this pull request by using MinecraftClient#crosshairTarget instead of raycasting manually.