### PR TITLE
Add show name option to PotionsHud

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19.4
 yarn_mappings=1.19.4+build.1
 loader_version=0.14.9
 # Mod Properties
-mod_version=2.2.6
+mod_version=2.2.7
 maven_group=io.github.darkkronicle
 archives_base_name=KronHUD
 # Dependencies

--- a/src/main/resources/assets/kronhud/lang/en_us.json
+++ b/src/main/resources/assets/kronhud/lang/en_us.json
@@ -228,5 +228,8 @@
   "option.kronhud.scoreboardhud.toppadding.comment": "Padding around the title component on the scoreboard",
 
   "option.kronhud.playerhud.dynamicrotation": "Dynamic Rotation",
-  "option.kronhud.playerhud.dynamicrotation.comment": "Rotation of the player is shown and then slowly turns back to looking straight"
+  "option.kronhud.playerhud.dynamicrotation.comment": "Rotation of the player is shown and then slowly turns back to looking straight",
+
+  "option.kronhud.potionshud.showname": "Show Name",
+  "option.kronhud.potionshud.showname.comment": "Whether to show the name and amplifier of the potion effect."
 }


### PR DESCRIPTION
Adds a show name option to PotionsHud, which will show the name and amplifier of the status effect (e.g. Speed II) along with the duration.

Y-axis:
![image](https://user-images.githubusercontent.com/55918888/236600864-afdfc2ef-448e-445f-b4b5-2320710656b5.png)

X-axis:
![image](https://user-images.githubusercontent.com/55918888/236600870-de254732-f76c-4637-9059-bdc0b8db04fc.png)

Feature request: https://discord.com/channels/753693459369427044/1100200670377820191
